### PR TITLE
feat: add chunker router, reranking, and embedding factories

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,7 +51,7 @@ local_files:
 
 # Embedding model configuration
 embedding:
-  # Provider: 'lmstudio' or 'sentence-transformers' (for backward compatibility)
+  # Provider: 'lmstudio' or 'openai'
   provider: lmstudio
   # LM Studio endpoint (OpenAI-compatible API)
   endpoint: "http://localhost:1234/v1"
@@ -61,6 +61,16 @@ embedding:
   batch_size: 32
   # Timeout for API requests (seconds)
   timeout: 30
+  # Provider-specific settings (preferred)
+  lmstudio:
+    base_url: "http://localhost:1234/v1"
+    model: "text-embedding-model-name"
+    timeout_seconds: 120
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+    base_url: null
+    model: "text-embedding-3-large"
+    timeout_seconds: 60
 
 # Vector storage configuration
 storage:
@@ -81,6 +91,39 @@ chunking:
   chunk_overlap: 256
   # Chunking strategy: 'character', 'token', or 'semantic'
   strategy: character
+  # New router configuration (vNext)
+  router_enabled: true
+  id_strategy: stable_hash  # stable_hash | legacy
+  defaults:
+    strategy: recursive
+    chunk_size: 2048
+    chunk_overlap: 256
+  markdown:
+    enabled: true
+    header_levels: [1, 2, 3]
+    max_section_tokens: 900
+  huge_docs:
+    enabled: true
+    huge_doc_tokens: 25000
+    levels:
+      coarse: { chunk_size: 2200, chunk_overlap: 200 }
+      mid:    { chunk_size: 700,  chunk_overlap: 100 }
+      fine:   { chunk_size: 220,  chunk_overlap: 40 }
+
+retrieval:
+  k_recall: 50
+  rerank:
+    enabled: true
+    type: llm  # none | llm | cross_encoder
+    top_n: 8
+    llm:
+      provider: lmstudio  # lmstudio | openai
+      model: null
+      max_tokens: 256
+      temperature: 0.0
+  expand:
+    include_parent: true
+    max_parents: 1
 
 # Output configuration
 output_folder: ./output

--- a/docs/CHUNKING_VNEXT.md
+++ b/docs/CHUNKING_VNEXT.md
@@ -1,0 +1,45 @@
+# Chunking vNext
+
+## Design statement
+
+Obsidian notes are treated as Markdown with an additional semantic layer (frontmatter, tags, links). All such semantics must be parsed, preserved, and surfaced as metadata. Generic Markdown parsing is insufficient.
+
+## Router rules
+
+The chunking router selects a chunker based on content and metadata:
+
+1. **Zotero annotations** (`source_type == "zotero_annotation"`) use the atomic chunker.
+2. **Obsidian notes** or Markdown-looking content use the Markdown chunker.
+3. **Huge documents** (token estimate above `chunking.huge_docs.huge_doc_tokens`) use the hierarchical chunker.
+4. **Fallback** uses the default `TextChunker`.
+
+## Chunk levels
+
+Chunks include a `chunk_level` metadata field:
+
+- `atomic`
+- `coarse`
+- `mid`
+- `fine`
+
+Hierarchical chunks include `parent_id` so fine chunks can resolve to mid, and mid can resolve to coarse when enabled.
+
+## Markdown semantics
+
+Markdown chunking respects the author’s structure:
+
+- YAML frontmatter is parsed and preserved in metadata.
+- Headings (`#`, `##`, `###`) define section boundaries.
+- Code blocks are preserved and never split across chunk boundaries.
+- Tags and wikilinks are extracted and stored in metadata (`tags`, `links_out`).
+- `heading_path` captures section context (e.g., `H1 > H2`).
+
+## Configuration knobs
+
+See `config.example.yaml` for the full configuration:
+
+- `chunking.router_enabled`
+- `chunking.id_strategy`
+- `chunking.defaults`
+- `chunking.markdown`
+- `chunking.huge_docs`

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1,0 +1,35 @@
+# Extending Re-Searcher
+
+## Add a new chunker
+
+1. Create a new chunker in `src/processing/chunkers/` implementing `chunk_with_metadata`.
+2. Add routing logic in `src/processing/router.py`.
+3. Update tests in `tests/unit/` for routing and metadata expectations.
+
+## Add a new reranker
+
+1. Implement a class in `src/retrieval/rerank.py`.
+2. Update `src/factories/reranker_factory.py` to select it by config.
+3. Add unit tests to validate ordering logic.
+
+## Add a new embedding provider
+
+1. Implement `EmbeddingProvider` in `src/embedding/`.
+2. Add a factory entry in `src/factories/embedding_factory.py`.
+3. Add a config section in `config.example.yaml`.
+
+## Switching embedding providers
+
+Update `embedding.provider` and the provider-specific section in `config.example.yaml`:
+
+```yaml
+embedding:
+  provider: openai
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+    model: "text-embedding-3-large"
+```
+
+## Provider isolation
+
+All provider-specific code should live behind factories so the pipeline stays stable.

--- a/docs/RERANKING.md
+++ b/docs/RERANKING.md
@@ -1,0 +1,38 @@
+# Re-ranking
+
+Re-ranking sits after vector recall and before optional parent-context expansion:
+
+```
+recall (k_recall) → rerank → truncate (k_return/top_n) → expand parent
+```
+
+## How it works
+
+- `k_recall` controls the number of candidates retrieved from the vector store.
+- When enabled, the reranker reorders candidates by relevance to the query.
+- The final result list is truncated to `k` or `rerank.top_n` (if set).
+
+## Configuration
+
+Configure in `config.example.yaml`:
+
+```yaml
+retrieval:
+  k_recall: 50
+  rerank:
+    enabled: true
+    type: llm
+    top_n: 8
+    llm:
+      provider: lmstudio
+      model: null
+      max_tokens: 256
+      temperature: 0.0
+  expand:
+    include_parent: true
+    max_parents: 1
+```
+
+## Switching providers
+
+The reranker currently supports LM Studio via its OpenAI-compatible chat endpoint. Additional providers can be added behind the reranker factory without touching the pipeline.

--- a/docs/START_HERE_TESTING.md
+++ b/docs/START_HERE_TESTING.md
@@ -123,6 +123,9 @@ Status:   Infrastructure ready, tests to implement
 # 👨‍💻 DURING DEVELOPMENT (instant feedback)
 pytest tests/unit/test_chunking.py -v
 
+# 🧪 vNext chunking + rerank smoke
+pytest tests/unit/test_chunk_id_stability.py tests/unit/test_router_routing.py -v
+
 # ✅ UNIT TESTS (all components)
 pytest tests/unit/ -v
 

--- a/src/embedding/__init__.py
+++ b/src/embedding/__init__.py
@@ -2,5 +2,6 @@
 
 from .base import EmbeddingProvider
 from .lmstudio import LMStudioEmbedding
+from .openai import OpenAIEmbedding
 
-__all__ = ["EmbeddingProvider", "LMStudioEmbedding"]
+__all__ = ["EmbeddingProvider", "LMStudioEmbedding", "OpenAIEmbedding"]

--- a/src/embedding/lmstudio.py
+++ b/src/embedding/lmstudio.py
@@ -13,12 +13,21 @@ class LMStudioEmbedding(EmbeddingProvider):
     def __init__(self, config: dict):
         super().__init__(config)
         embedding_config = config.get("embedding", {})
+        lmstudio_config = embedding_config.get("lmstudio", {})
 
-        self.endpoint = embedding_config.get("endpoint", "http://localhost:1234/v1")
-        self.model = embedding_config.get("model", "text-embedding-bge-m3")
-        self.batch_size = embedding_config.get("batch_size", 32)
-        self.timeout = embedding_config.get("timeout", 30)
-        self.api_key = embedding_config.get("api_key")  # optional API key
+        self.endpoint = (
+            lmstudio_config.get("base_url")
+            or embedding_config.get("endpoint")
+            or "http://localhost:1234/v1"
+        )
+        self.model = (
+            lmstudio_config.get("model")
+            or embedding_config.get("model")
+            or "text-embedding-bge-m3"
+        )
+        self.batch_size = lmstudio_config.get("batch_size", embedding_config.get("batch_size", 32))
+        self.timeout = lmstudio_config.get("timeout_seconds", embedding_config.get("timeout", 30))
+        self.api_key = lmstudio_config.get("api_key") or embedding_config.get("api_key")
 
         # Initialize OpenAI client pointing to LM Studio
         client_kwargs = {"base_url": self.endpoint, "timeout": self.timeout}

--- a/src/embedding/openai.py
+++ b/src/embedding/openai.py
@@ -1,0 +1,67 @@
+"""OpenAI embedding provider."""
+
+import os
+from typing import List
+
+from openai import OpenAI
+
+from .base import EmbeddingProvider
+
+
+class OpenAIEmbedding(EmbeddingProvider):
+    """Embedding provider using OpenAI's API."""
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        embedding_config = config.get("embedding", {})
+        openai_config = embedding_config.get("openai", {})
+
+        api_key = openai_config.get("api_key") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OpenAI API key not configured. Set embedding.openai.api_key or OPENAI_API_KEY.")
+
+        base_url = openai_config.get("base_url")
+        model = openai_config.get("model", "text-embedding-3-large")
+        timeout = openai_config.get("timeout_seconds", 60)
+        batch_size = openai_config.get("batch_size", 32)
+
+        client_kwargs = {"api_key": api_key, "timeout": timeout}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+
+        self.client = OpenAI(**client_kwargs)
+        self.model = model
+        self.batch_size = batch_size
+        self._dimension = None
+
+    def embed_texts(self, texts: List[str]) -> List[List[float]]:
+        if not texts:
+            return []
+
+        embeddings = []
+        for i in range(0, len(texts), self.batch_size):
+            batch = texts[i : i + self.batch_size]
+            response = self.client.embeddings.create(model=self.model, input=batch)
+            batch_embeddings = [item.embedding for item in response.data]
+            embeddings.extend(batch_embeddings)
+
+            if self._dimension is None and batch_embeddings:
+                self._dimension = len(batch_embeddings[0])
+
+        return embeddings
+
+    def embed_query(self, query: str) -> List[float]:
+        response = self.client.embeddings.create(model=self.model, input=[query])
+        embedding = response.data[0].embedding
+
+        if self._dimension is None:
+            self._dimension = len(embedding)
+
+        return embedding
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is None:
+            dummy_embedding = self.embed_query("dimension probe")
+            self._dimension = len(dummy_embedding)
+        return self._dimension

--- a/src/factories/__init__.py
+++ b/src/factories/__init__.py
@@ -1,0 +1,1 @@
+"""Factory modules."""

--- a/src/factories/chunker_factory.py
+++ b/src/factories/chunker_factory.py
@@ -1,0 +1,14 @@
+"""Chunker factory."""
+
+from typing import Any, Dict
+
+from src.processing.chunker import TextChunker
+from src.processing.router import ChunkerRouter
+
+
+def create_chunker(config: Dict[str, Any]):
+    """Create chunker based on router settings."""
+    chunking_config = config.get("chunking", {})
+    if chunking_config.get("router_enabled", False):
+        return ChunkerRouter(config)
+    return TextChunker(config)

--- a/src/factories/embedding_factory.py
+++ b/src/factories/embedding_factory.py
@@ -1,0 +1,25 @@
+"""Embedding provider factory."""
+
+from typing import Any, Dict
+
+from src.embedding.lmstudio import LMStudioEmbedding
+from src.embedding.openai import OpenAIEmbedding
+
+
+SUPPORTED_PROVIDERS = {"lmstudio", "openai"}
+
+
+def create_embedder(config: Dict[str, Any]):
+    """Create embedding provider from config."""
+    embedding_config = config.get("embedding", {})
+    provider = embedding_config.get("provider", "lmstudio")
+
+    if provider == "lmstudio":
+        return LMStudioEmbedding(config)
+    if provider == "openai":
+        return OpenAIEmbedding(config)
+
+    raise ValueError(
+        f"Unsupported embedding provider '{provider}'. "
+        f"Supported providers: {', '.join(sorted(SUPPORTED_PROVIDERS))}."
+    )

--- a/src/factories/reranker_factory.py
+++ b/src/factories/reranker_factory.py
@@ -1,0 +1,20 @@
+"""Reranker factory."""
+
+from typing import Any, Dict
+
+from src.retrieval.rerank import LLMReranker, NoRerank
+
+
+def create_reranker(config: Dict[str, Any]):
+    """Create reranker from config."""
+    rerank_config = config.get("retrieval", {}).get("rerank", {})
+    if not rerank_config.get("enabled", False):
+        return NoRerank(config)
+
+    rerank_type = rerank_config.get("type", "llm")
+    if rerank_type == "llm":
+        return LLMReranker(config)
+    if rerank_type == "none":
+        return NoRerank(config)
+
+    raise ValueError(f"Unsupported rerank type '{rerank_type}'.")

--- a/src/llm_clients/__init__.py
+++ b/src/llm_clients/__init__.py
@@ -1,0 +1,1 @@
+"""LLM client implementations."""

--- a/src/llm_clients/lmstudio_client.py
+++ b/src/llm_clients/lmstudio_client.py
@@ -1,0 +1,48 @@
+"""LM Studio chat-completions client."""
+
+from typing import Any, Dict, Optional
+
+from openai import OpenAI
+
+
+class LMStudioClient:
+    """Client for LM Studio's OpenAI-compatible chat API."""
+
+    def __init__(self, config: Dict[str, Any]):
+        llm_config = config.get("retrieval", {}).get("rerank", {}).get("llm", {})
+
+        embedding_config = config.get("embedding", {})
+        lmstudio_config = embedding_config.get("lmstudio", {})
+
+        base_url = lmstudio_config.get("base_url") or embedding_config.get("endpoint")
+        timeout = lmstudio_config.get("timeout_seconds") or embedding_config.get("timeout") or 60
+        api_key = lmstudio_config.get("api_key") or embedding_config.get("api_key")
+
+        if not base_url:
+            base_url = "http://localhost:1234/v1"
+
+        client_kwargs: Dict[str, Any] = {"base_url": base_url, "timeout": timeout}
+        if api_key:
+            client_kwargs["api_key"] = api_key
+
+        self.client = OpenAI(**client_kwargs)
+        self.default_model = llm_config.get("model")
+
+    def chat_completion(
+        self,
+        system_prompt: str,
+        user_message: str,
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+    ) -> str:
+        response = self.client.chat.completions.create(
+            model=model or self.default_model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return response.choices[0].message.content

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from tqdm import tqdm
 
-from .embedding.lmstudio import LMStudioEmbedding
+from .factories.chunker_factory import create_chunker
+from .factories.embedding_factory import create_embedder
+from .factories.reranker_factory import create_reranker
 from .indexing import DocumentStatus, IndexingProgress
-from .processing.chunker import TextChunker
+from .processing.id_utils import attach_parent_ids, stable_chunk_id
+from .retrieval.expand import attach_parent_context
 from .sources.obsidian import ObsidianSource
 from .sources.zotero import ZoteroSource
 from .storage.chroma import ChromaVectorStore
@@ -30,8 +32,9 @@ class ResearchRAGPipeline:
 
         # Initialize components
         self.sources = self._initialize_sources()
-        self.chunker = TextChunker(self.config)
-        self.embedder = LMStudioEmbedding(self.config)
+        self.chunker = create_chunker(self.config)
+        self.embedder = create_embedder(self.config)
+        self.reranker = create_reranker(self.config)
         self.vector_store = ChromaVectorStore(self.config)
 
         # Output directory for metadata
@@ -258,39 +261,20 @@ class ResearchRAGPipeline:
                     all_metadatas.append(chunk_metadata)
 
                     # Generate unique ID for chunk
-                    chunk_id = f"{doc.doc_id}-chunk-{idx}"
+                    chunking_config = self.config.get("chunking", {})
+                    id_strategy = chunking_config.get("id_strategy", "legacy")
+                    if id_strategy == "legacy":
+                        chunk_id = f"{doc.doc_id}-chunk-{idx}"
+                    else:
+                        source_id = doc.doc_id
+                        level = chunk_metadata.get("chunk_level", "mid")
+                        chunk_id = stable_chunk_id(source_id, level, idx, chunk_text)
                     all_ids.append(chunk_id)
 
             except Exception as e:
                 print(f"  [WARNING] Error chunking document {doc.doc_id}: {e}")
 
-        return all_chunks, all_metadatas, all_ids
-
-    def _chunk_documents(self, documents: List) -> tuple:
-        """
-        Chunk documents into smaller segments.
-
-        Returns:
-            Tuple of (chunks, metadatas, ids)
-        """
-        all_chunks = []
-        all_metadatas = []
-        all_ids = []
-
-        for doc in tqdm(documents, desc="Chunking"):
-            try:
-                chunk_data = self.chunker.chunk_with_metadata(doc.content, doc.metadata)
-
-                for idx, (chunk_text, chunk_metadata) in enumerate(chunk_data):
-                    all_chunks.append(chunk_text)
-                    all_metadatas.append(chunk_metadata)
-
-                    # Generate unique ID for chunk
-                    chunk_id = f"{doc.doc_id}-chunk-{idx}"
-                    all_ids.append(chunk_id)
-
-            except Exception as e:
-                print(f"  [WARNING] Error chunking document {doc.doc_id}: {e}")
+        attach_parent_ids(all_metadatas, all_ids)
 
         return all_chunks, all_metadatas, all_ids
 
@@ -324,29 +308,6 @@ class ResearchRAGPipeline:
                 )
         except Exception as e:
             print(f"[ERROR] Error storing embeddings: {e}")
-            raise
-
-    def _store_embeddings(
-        self,
-        chunks: List[str],
-        embeddings: List[List[float]],
-        metadatas: List[Dict[str, Any]],
-        ids: List[str],
-    ):
-        """Store embeddings in vector database."""
-        try:
-            # Store in batches to avoid overwhelming ChromaDB
-            batch_size = 100
-            for i in tqdm(range(0, len(chunks), batch_size), desc="Storing"):
-                batch_end = min(i + batch_size, len(chunks))
-                self.vector_store.add_documents(
-                    texts=chunks[i:batch_end],
-                    embeddings=embeddings[i:batch_end],
-                    metadatas=metadatas[i:batch_end],
-                    ids=ids[i:batch_end],
-                )
-        except Exception as e:
-            print(f"❌ Error storing embeddings: {e}")
             raise
 
     def _compute_source_hash(self) -> str:
@@ -408,7 +369,25 @@ class ResearchRAGPipeline:
         # Generate query embedding
         query_embedding = self.embedder.embed_query(query_text)
 
+        retrieval_config = self.config.get("retrieval", {})
+        k_recall = retrieval_config.get("k_recall", 50)
+        k_return = k
+
         # Search vector store
-        results = self.vector_store.search(query_embedding, k=k)
+        results = self.vector_store.search(query_embedding, k=k_recall)
+
+        rerank_config = retrieval_config.get("rerank", {})
+        if rerank_config.get("enabled", False):
+            results = self.reranker.rerank(query_text, results)
+            top_n = rerank_config.get("top_n")
+            limit = k_return if top_n is None else min(k_return, top_n)
+            results = results[:limit]
+        else:
+            results = results[:k_return]
+
+        expand_config = retrieval_config.get("expand", {})
+        if expand_config.get("include_parent", False):
+            max_parents = expand_config.get("max_parents", 1)
+            results = attach_parent_context(results, self.vector_store, max_parents=max_parents)
 
         return results

--- a/src/processing/chunker.py
+++ b/src/processing/chunker.py
@@ -13,6 +13,10 @@ class TextChunker:
 
     def __init__(self, config: Dict[str, Any]):
         chunking_config = config.get("chunking", {})
+        if "defaults" in chunking_config:
+            chunking_config = chunking_config.get("defaults", {})
+        if "defaults" in chunking_config:
+            chunking_config = chunking_config.get("defaults", {})
 
         self.chunk_size = chunking_config.get("chunk_size", 2048)
         self.chunk_overlap = chunking_config.get("chunk_overlap", 256)
@@ -101,6 +105,7 @@ class TextChunker:
             chunk_metadata = base_metadata.copy()
             chunk_metadata["chunk_index"] = idx
             chunk_metadata["total_chunks"] = len(chunks)
+            chunk_metadata.setdefault("chunk_level", "mid")
             chunk_data.append((chunk, chunk_metadata))
 
         return chunk_data

--- a/src/processing/chunkers/__init__.py
+++ b/src/processing/chunkers/__init__.py
@@ -1,0 +1,7 @@
+"""Chunker implementations."""
+
+from .atomic import AtomicChunker
+from .hierarchical import HierarchicalChunker
+from .markdown import MarkdownChunker
+
+__all__ = ["AtomicChunker", "HierarchicalChunker", "MarkdownChunker"]

--- a/src/processing/chunkers/atomic.py
+++ b/src/processing/chunkers/atomic.py
@@ -1,0 +1,23 @@
+"""Atomic chunker for single chunk documents."""
+
+from typing import Any, Dict, List, Tuple
+
+
+class AtomicChunker:
+    """Return a single chunk for the full text."""
+
+    def chunk_with_metadata(
+        self, text: str, base_metadata: Dict[str, Any]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        if not text or not text.strip():
+            return []
+
+        chunk_metadata = base_metadata.copy()
+        chunk_metadata.update(
+            {
+                "chunk_index": 0,
+                "total_chunks": 1,
+                "chunk_level": "atomic",
+            }
+        )
+        return [(text.strip(), chunk_metadata)]

--- a/src/processing/chunkers/hierarchical.py
+++ b/src/processing/chunkers/hierarchical.py
@@ -1,0 +1,90 @@
+"""Hierarchical chunker for huge documents."""
+
+from typing import Any, Dict, List, Tuple
+
+from src.processing.chunker import TextChunker
+
+
+class HierarchicalChunker:
+    """Chunk text into coarse, mid, and fine levels with lineage metadata."""
+
+    def __init__(self, config: Dict[str, Any]):
+        chunking_config = config.get("chunking", {})
+        defaults = chunking_config.get("defaults", chunking_config)
+        huge_docs = chunking_config.get("huge_docs", {})
+        levels = huge_docs.get("levels", {})
+
+        self.levels_config = {
+            "coarse": {**defaults, **levels.get("coarse", {})},
+            "mid": {**defaults, **levels.get("mid", {})},
+            "fine": {**defaults, **levels.get("fine", {})},
+        }
+
+    def chunk_with_metadata(
+        self, text: str, base_metadata: Dict[str, Any]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        if not text or not text.strip():
+            return []
+
+        coarse_texts = self._chunk_level(text, "coarse")
+        coarse_chunks: List[Tuple[str, Dict[str, Any]]] = []
+        mid_chunks: List[Tuple[str, Dict[str, Any]]] = []
+        fine_chunks: List[Tuple[str, Dict[str, Any]]] = []
+
+        mid_counter = 0
+        fine_counter = 0
+
+        for coarse_idx, coarse_text in enumerate(coarse_texts):
+            coarse_metadata = base_metadata.copy()
+            coarse_metadata.update(
+                {
+                    "chunk_level": "coarse",
+                    "chunk_index": coarse_idx,
+                }
+            )
+            coarse_chunks.append((coarse_text, coarse_metadata))
+
+            mid_texts = self._chunk_level(coarse_text, "mid")
+            for mid_text in mid_texts:
+                mid_metadata = base_metadata.copy()
+                mid_metadata.update(
+                    {
+                        "chunk_level": "mid",
+                        "chunk_index": mid_counter,
+                        "parent_level": "coarse",
+                        "parent_ordinal": coarse_idx,
+                    }
+                )
+                mid_chunks.append((mid_text, mid_metadata))
+                parent_mid_index = mid_counter
+                mid_counter += 1
+
+                fine_texts = self._chunk_level(mid_text, "fine")
+                for fine_text in fine_texts:
+                    fine_metadata = base_metadata.copy()
+                    fine_metadata.update(
+                        {
+                            "chunk_level": "fine",
+                            "chunk_index": fine_counter,
+                            "parent_level": "mid",
+                            "parent_ordinal": parent_mid_index,
+                        }
+                    )
+                    fine_chunks.append((fine_text, fine_metadata))
+                    fine_counter += 1
+
+        self._apply_total_counts(coarse_chunks)
+        self._apply_total_counts(mid_chunks)
+        self._apply_total_counts(fine_chunks)
+
+        return coarse_chunks + mid_chunks + fine_chunks
+
+    def _chunk_level(self, text: str, level: str) -> List[str]:
+        config = {"chunking": self.levels_config[level]}
+        chunker = TextChunker(config)
+        return chunker.chunk_text(text)
+
+    def _apply_total_counts(self, chunks: List[Tuple[str, Dict[str, Any]]]):
+        total = len(chunks)
+        for _, metadata in chunks:
+            metadata["total_chunks"] = total

--- a/src/processing/chunkers/markdown.py
+++ b/src/processing/chunkers/markdown.py
@@ -1,0 +1,176 @@
+"""Markdown-aware chunker with Obsidian semantics."""
+
+import re
+from typing import Any, Dict, List, Tuple
+
+from src.processing.chunker import TextChunker
+
+
+class MarkdownChunker:
+    """Chunk markdown documents by headings with safe fallback splitting."""
+
+    def __init__(self, config: Dict[str, Any]):
+        chunking_config = config.get("chunking", {})
+        defaults = chunking_config.get("defaults", chunking_config)
+        markdown_config = chunking_config.get("markdown", {})
+
+        self.text_chunker = TextChunker({"chunking": defaults})
+        self.header_levels = set(markdown_config.get("header_levels", [1, 2, 3]))
+        self.max_section_tokens = markdown_config.get("max_section_tokens", 900)
+
+    def chunk_with_metadata(
+        self, text: str, base_metadata: Dict[str, Any]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        if not text or not text.strip():
+            return []
+
+        sections = self._split_by_headings(text)
+        chunks: List[Tuple[str, Dict[str, Any]]] = []
+        for section in sections:
+            section_chunks = self._chunk_section(section)
+            for chunk_text, contains_code in section_chunks:
+                chunk_metadata = base_metadata.copy()
+                chunk_metadata.update(
+                    {
+                        "chunk_level": "mid",
+                        "heading_path": section["heading_path"],
+                        "contains_code": contains_code,
+                    }
+                )
+                chunks.append((chunk_text, chunk_metadata))
+
+        for idx, (_, metadata) in enumerate(chunks):
+            metadata["chunk_index"] = idx
+            metadata["total_chunks"] = len(chunks)
+
+        return chunks
+
+    def _split_by_headings(self, text: str) -> List[Dict[str, Any]]:
+        lines = text.splitlines()
+        sections = []
+        current_lines: List[str] = []
+        heading_stack: List[str] = []
+        current_heading_path = ""
+        in_code_block = False
+        fence_pattern = re.compile(r"^(```|~~~)")
+        heading_pattern = re.compile(r"^(#{1,6})\s+(.*)$")
+
+        def flush_section():
+            if current_lines:
+                sections.append(
+                    {
+                        "heading_path": current_heading_path,
+                        "content": "\n".join(current_lines).strip(),
+                    }
+                )
+
+        for line in lines:
+            if fence_pattern.match(line.strip()):
+                in_code_block = not in_code_block
+
+            heading_match = heading_pattern.match(line) if not in_code_block else None
+            if heading_match:
+                level = len(heading_match.group(1))
+                if level in self.header_levels:
+                    flush_section()
+                    current_lines = [line]
+                    heading_text = heading_match.group(2).strip()
+
+                    while len(heading_stack) >= level:
+                        heading_stack.pop()
+                    heading_stack.append(heading_text)
+                    current_heading_path = " > ".join(heading_stack)
+                    continue
+
+            current_lines.append(line)
+
+        flush_section()
+        return sections
+
+    def _chunk_section(self, section: Dict[str, Any]) -> List[Tuple[str, bool]]:
+        content = section.get("content", "")
+        if not content.strip():
+            return []
+
+        if self._estimate_tokens(content) <= self.max_section_tokens:
+            contains_code = self._contains_code_block(content)
+            return [(content.strip(), contains_code)]
+
+        return self._split_large_section(content)
+
+    def _split_large_section(self, content: str) -> List[Tuple[str, bool]]:
+        segments = self._segment_by_code_blocks(content)
+        chunk_size_chars = self.text_chunker.chunk_size
+        chunks: List[Tuple[str, bool]] = []
+        current_parts: List[str] = []
+        current_size = 0
+        current_contains_code = False
+
+        for segment_text, is_code in segments:
+            segment_size = len(segment_text)
+            if current_parts and current_size + segment_size > chunk_size_chars:
+                chunk_text = "\n".join(current_parts).strip()
+                if chunk_text:
+                    chunks.append((chunk_text, current_contains_code))
+                current_parts = []
+                current_size = 0
+                current_contains_code = False
+
+            current_parts.append(segment_text)
+            current_size += segment_size
+            current_contains_code = current_contains_code or is_code
+
+        if current_parts:
+            chunk_text = "\n".join(current_parts).strip()
+            if chunk_text:
+                chunks.append((chunk_text, current_contains_code))
+
+        if not chunks:
+            return [(content.strip(), self._contains_code_block(content))]
+
+        return chunks
+
+    def _segment_by_code_blocks(self, content: str) -> List[Tuple[str, bool]]:
+        lines = content.splitlines()
+        segments: List[Tuple[str, bool]] = []
+        buffer: List[str] = []
+        in_code_block = False
+        fence_pattern = re.compile(r"^(```|~~~)")
+
+        def flush_buffer(is_code: bool):
+            if buffer:
+                segments.append(("\n".join(buffer).strip(), is_code))
+                buffer.clear()
+
+        for line in lines:
+            if fence_pattern.match(line.strip()):
+                if in_code_block:
+                    buffer.append(line)
+                    flush_buffer(True)
+                    in_code_block = False
+                    continue
+                flush_buffer(False)
+                in_code_block = True
+                buffer.append(line)
+                continue
+
+            buffer.append(line)
+
+        flush_buffer(in_code_block)
+
+        paragraph_segments: List[Tuple[str, bool]] = []
+        for segment_text, is_code in segments:
+            if is_code:
+                paragraph_segments.append((segment_text, True))
+                continue
+            for paragraph in re.split(r"\n\s*\n", segment_text):
+                if paragraph.strip():
+                    paragraph_segments.append((paragraph.strip(), False))
+
+        return paragraph_segments
+
+    def _contains_code_block(self, text: str) -> bool:
+        return bool(re.search(r"(^|\n)```", text)) or bool(re.search(r"(^|\n)~~~", text))
+
+    def _estimate_tokens(self, text: str) -> int:
+        return max(1, len(text) // 4)

--- a/src/processing/id_utils.py
+++ b/src/processing/id_utils.py
@@ -1,0 +1,31 @@
+"""Utilities for stable chunk ID generation."""
+
+import hashlib
+
+
+def stable_chunk_id(source_id: str, level: str, ordinal: int, chunk_text: str) -> str:
+    """Generate stable chunk ID using content-derived hash."""
+    snippet = chunk_text[:256]
+    snippet_hash = hashlib.sha1(snippet.encode("utf-8")).hexdigest()
+    composite = f"{source_id}|{level}|{ordinal}|{snippet_hash}"
+    digest = hashlib.sha1(composite.encode("utf-8")).hexdigest()
+    return f"{source_id}-{level}-{ordinal}-{digest}"
+
+
+def attach_parent_ids(metadatas: list[dict], ids: list[str]) -> None:
+    """Attach parent_id to metadata entries based on parent_level/parent_ordinal."""
+    id_lookup = {}
+    for metadata, chunk_id in zip(metadatas, ids):
+        level = metadata.get("chunk_level")
+        ordinal = metadata.get("chunk_index")
+        if level is not None and ordinal is not None:
+            id_lookup[(level, ordinal)] = chunk_id
+
+    for metadata in metadatas:
+        parent_level = metadata.get("parent_level")
+        parent_ordinal = metadata.get("parent_ordinal")
+        if parent_level is None or parent_ordinal is None:
+            continue
+        parent_id = id_lookup.get((parent_level, parent_ordinal))
+        if parent_id:
+            metadata["parent_id"] = parent_id

--- a/src/processing/router.py
+++ b/src/processing/router.py
@@ -1,0 +1,63 @@
+"""Chunking router with adaptive logic."""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from src.processing.chunker import TextChunker
+from src.processing.chunkers.atomic import AtomicChunker
+from src.processing.chunkers.hierarchical import HierarchicalChunker
+from src.processing.chunkers.markdown import MarkdownChunker
+
+
+class ChunkerRouter:
+    """Route documents to appropriate chunkers based on metadata and content."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        chunking_config = config.get("chunking", {})
+        self.defaults = chunking_config.get("defaults", chunking_config)
+        self.huge_docs_config = chunking_config.get("huge_docs", {})
+        self.markdown_enabled = chunking_config.get("markdown", {}).get("enabled", True)
+
+        self.atomic_chunker = AtomicChunker()
+        self.markdown_chunker = MarkdownChunker(config)
+        self.hierarchical_chunker = HierarchicalChunker(config)
+        self.default_chunker = TextChunker({"chunking": self.defaults})
+
+    def chunk_with_metadata(
+        self, text: str, metadata: Dict[str, Any]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        if not text or not text.strip():
+            return []
+
+        source_type = metadata.get("source_type")
+        if source_type == "zotero_annotation":
+            return self.atomic_chunker.chunk_with_metadata(text, metadata)
+
+        if self.markdown_enabled and self._is_markdown(metadata, text):
+            return self.markdown_chunker.chunk_with_metadata(text, metadata)
+
+        if self._is_huge_document(text):
+            return self.hierarchical_chunker.chunk_with_metadata(text, metadata)
+
+        return self.default_chunker.chunk_with_metadata(text, metadata)
+
+    def _is_markdown(self, metadata: Dict[str, Any], text: str) -> bool:
+        if metadata.get("source_type") == "obsidian":
+            return True
+
+        file_path = metadata.get("file_path") or metadata.get("file_name")
+        if file_path:
+            if Path(str(file_path)).suffix.lower() == ".md":
+                return True
+
+        return bool(re.search(r"^#{1,6}\s+", text, re.MULTILINE))
+
+    def _is_huge_document(self, text: str) -> bool:
+        if not self.huge_docs_config.get("enabled", False):
+            return False
+
+        huge_doc_tokens = self.huge_docs_config.get("huge_doc_tokens", 25000)
+        estimated_tokens = max(1, len(text) // 4)
+        return estimated_tokens >= huge_doc_tokens

--- a/src/retrieval/__init__.py
+++ b/src/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Retrieval utilities."""

--- a/src/retrieval/expand.py
+++ b/src/retrieval/expand.py
@@ -1,0 +1,52 @@
+"""Parent-context expansion utilities."""
+
+from typing import Any, Dict, List, Tuple
+
+
+ResultTuple = Tuple[str, str, float, Dict[str, Any]]
+
+
+def attach_parent_context(
+    results: List[ResultTuple],
+    vector_store,
+    max_parents: int = 1,
+) -> List[ResultTuple]:
+    """Attach parent context text for results with parent IDs."""
+    if not results or max_parents <= 0:
+        return results
+
+    parent_ids = []
+    for _, _, _, metadata in results:
+        parent_id = metadata.get("parent_id")
+        if not parent_id:
+            continue
+        if isinstance(parent_id, list):
+            parent_ids.extend(parent_id[:max_parents])
+        else:
+            parent_ids.append(parent_id)
+
+    if not parent_ids:
+        return results
+
+    parent_records = vector_store.get_by_ids(parent_ids)
+    parent_lookup = {record[0]: record for record in parent_records}
+
+    enriched_results = []
+    for doc_id, text, score, metadata in results:
+        new_metadata = dict(metadata)
+        parent_id = metadata.get("parent_id")
+        if isinstance(parent_id, list):
+            attached = []
+            for pid in parent_id[:max_parents]:
+                if pid in parent_lookup:
+                    _, parent_text, parent_metadata = parent_lookup[pid]
+                    attached.append({\"id\": pid, \"text\": parent_text, \"metadata\": parent_metadata})
+            if attached:
+                new_metadata[\"parent_contexts\"] = attached
+        elif parent_id and parent_id in parent_lookup:
+            _, parent_text, parent_metadata = parent_lookup[parent_id]
+            new_metadata[\"parent_text\"] = parent_text
+            new_metadata[\"parent_metadata\"] = parent_metadata
+        enriched_results.append((doc_id, text, score, new_metadata))
+
+    return enriched_results

--- a/src/retrieval/rerank.py
+++ b/src/retrieval/rerank.py
@@ -1,0 +1,120 @@
+"""Re-ranking implementations for recall results."""
+
+import json
+import os
+from typing import Any, Dict, List, Tuple
+
+from openai import OpenAI
+
+from src.llm_clients.lmstudio_client import LMStudioClient
+
+ResultTuple = Tuple[str, str, float, Dict[str, Any]]
+
+
+class BaseReranker:
+    """Base class for reranking implementations."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    def rerank(self, query: str, results: List[ResultTuple]) -> List[ResultTuple]:
+        raise NotImplementedError
+
+
+class NoRerank(BaseReranker):
+    """No-op reranker."""
+
+    def rerank(self, query: str, results: List[ResultTuple]) -> List[ResultTuple]:
+        return results
+
+
+class LLMReranker(BaseReranker):
+    """LLM-based reranker using LM Studio or OpenAI style endpoints."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        rerank_config = config.get("retrieval", {}).get("rerank", {})
+        llm_config = rerank_config.get("llm", {})
+
+        self.provider = llm_config.get("provider", "lmstudio")
+        self.model = llm_config.get("model")
+        self.max_tokens = llm_config.get("max_tokens", 256)
+        self.temperature = llm_config.get("temperature", 0.0)
+
+        if self.provider == "lmstudio":
+            self.client = LMStudioClient(config)
+        elif self.provider == "openai":
+            embedding_config = config.get("embedding", {})
+            openai_config = embedding_config.get("openai", {})
+            api_key = openai_config.get("api_key") or os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError("OpenAI API key not configured for reranking.")
+            if not self.model:
+                raise ValueError("OpenAI reranker requires a model name.")
+            client_kwargs: Dict[str, Any] = {"api_key": api_key}
+            base_url = openai_config.get("base_url")
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            self.client = OpenAI(**client_kwargs)
+        else:
+            raise ValueError(f"Unsupported rerank provider '{self.provider}'.")
+
+    def rerank(self, query: str, results: List[ResultTuple]) -> List[ResultTuple]:
+        if not results:
+            return results
+
+        payload = {
+            "query": query,
+            "results": [
+                {
+                    "id": doc_id,
+                    "text": text,
+                }
+                for doc_id, text, _, _ in results
+            ],
+        }
+
+        prompt = (
+            "You are a relevance reranker. "
+            "Score each candidate from 0 to 100 based on relevance to the query. "
+            "Return strict JSON as {\"scores\": [{\"id\": ..., \"score\": ...}, ...]}."
+        )
+
+        response_text = self._invoke_model(prompt, payload)
+
+        try:
+            parsed = json.loads(response_text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON from reranker: {response_text}") from exc
+
+        scores = {item["id"]: item.get("score", 0) for item in parsed.get("scores", [])}
+        reranked = []
+        for doc_id, text, score, metadata in results:
+            rerank_score = scores.get(doc_id, 0)
+            new_metadata = dict(metadata)
+            new_metadata["rerank_score"] = rerank_score
+            reranked.append((doc_id, text, score, new_metadata))
+
+        reranked.sort(key=lambda item: item[3].get("rerank_score", 0), reverse=True)
+        return reranked
+
+    def _invoke_model(self, prompt: str, payload: Dict[str, Any]) -> str:
+        if self.provider == "lmstudio":
+            return self.client.chat_completion(
+                system_prompt=prompt,
+                user_message=json.dumps(payload),
+                model=self.model,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+            )
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": json.dumps(payload)},
+            ],
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+        )
+        return response.choices[0].message.content

--- a/src/sources/obsidian.py
+++ b/src/sources/obsidian.py
@@ -2,7 +2,9 @@
 
 import re
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Set
+
+import yaml
 
 from .base import DataSource, Document
 
@@ -56,9 +58,11 @@ class ObsidianSource(DataSource):
         md_files = self._find_markdown_files(include_folders, exclude_folders)
         print(f"📔 Found {len(md_files)} markdown files in Obsidian vault")
 
+        link_map = self._build_link_map(md_files)
+
         for md_file in md_files:
             try:
-                document = self._process_markdown_file(md_file)
+                document = self._process_markdown_file(md_file, link_map)
                 if document:
                     yield document
             except Exception as e:
@@ -98,7 +102,9 @@ class ObsidianSource(DataSource):
 
         return filtered_files
 
-    def _process_markdown_file(self, md_file: Path) -> Document:
+    def _process_markdown_file(
+        self, md_file: Path, link_map: Dict[str, str]
+    ) -> Document:
         """Process a single markdown file."""
         with open(md_file, "r", encoding="utf-8") as f:
             content = f.read()
@@ -108,6 +114,11 @@ class ObsidianSource(DataSource):
 
         # Extract wikilinks and backlinks
         wikilinks = self._extract_wikilinks(body)
+        resolved_links = self._resolve_wikilinks(wikilinks, link_map)
+        inline_tags = self._extract_inline_tags(body)
+        frontmatter_tags = self._extract_frontmatter_tags(frontmatter)
+        tags = self._normalize_tags(frontmatter_tags | inline_tags)
+        zotero_keys = self._extract_zotero_keys(frontmatter, body)
 
         # Get relative path from vault root
         relative_path = md_file.relative_to(self.vault_path)
@@ -121,13 +132,19 @@ class ObsidianSource(DataSource):
             "file_name": md_file.name,
             "title": frontmatter.get("title", md_file.stem),
             "wikilinks": wikilinks,
+            "links_out": resolved_links,
+            "tags": tags,
             "backlink": f"obsidian://open?vault={self.vault_path.name}&file={relative_path}",
+            "frontmatter": frontmatter,
         }
 
         # Add frontmatter fields to metadata
         for key, value in frontmatter.items():
             if key not in metadata:
                 metadata[key] = value
+
+        if zotero_keys:
+            metadata["zotero_key"] = zotero_keys[0] if len(zotero_keys) == 1 else zotero_keys
 
         return Document(
             content=body,
@@ -152,27 +169,48 @@ class ObsidianSource(DataSource):
                 frontmatter_text = parts[1].strip()
                 body = parts[2].strip()
 
-                # Simple YAML parsing (key: value format)
-                for line in frontmatter_text.split("\n"):
-                    if ":" in line:
-                        key, value = line.split(":", 1)
-                        key = key.strip()
-                        value = value.strip()
-
-                        # Try to parse lists
-                        if value.startswith("[") and value.endswith("]"):
-                            # Simple list parsing
-                            value = [v.strip().strip('"\'') for v in value[1:-1].split(",")]
-                        # Try to parse booleans
-                        elif value.lower() in ("true", "false"):
-                            value = value.lower() == "true"
-                        # Try to parse numbers
-                        elif value.isdigit():
-                            value = int(value)
-
-                        frontmatter[key] = value
+                try:
+                    loaded = yaml.safe_load(frontmatter_text)
+                    if isinstance(loaded, dict):
+                        frontmatter = loaded
+                except yaml.YAMLError:
+                    frontmatter = {}
 
         return frontmatter, body
+
+    def _extract_inline_tags(self, content: str) -> Set[str]:
+        pattern = re.compile(r"(?<!\w)#([\w/-]+)")
+        return set(pattern.findall(content))
+
+    def _extract_frontmatter_tags(self, frontmatter: Dict[str, Any]) -> Set[str]:
+        tags = frontmatter.get("tags", [])
+        if isinstance(tags, str):
+            return {tags}
+        if isinstance(tags, list):
+            return {str(tag) for tag in tags}
+        return set()
+
+    def _normalize_tags(self, tags: Set[str]) -> List[str]:
+        normalized = []
+        for tag in tags:
+            tag_text = str(tag).lstrip("#").strip().lower()
+            if tag_text:
+                normalized.append(tag_text)
+        return sorted(set(normalized))
+
+    def _extract_zotero_keys(self, frontmatter: Dict[str, Any], content: str) -> List[str]:
+        zotero_keys = []
+        frontmatter_key = frontmatter.get("zotero_key") or frontmatter.get("citekey")
+        if frontmatter_key:
+            if isinstance(frontmatter_key, list):
+                zotero_keys.extend(str(key) for key in frontmatter_key)
+            else:
+                zotero_keys.append(str(frontmatter_key))
+
+        inline_keys = re.findall(r"@([A-Za-z0-9_:-]+)", content)
+        zotero_keys.extend(inline_keys)
+
+        return list(dict.fromkeys(zotero_keys))
 
     def _extract_wikilinks(self, content: str) -> List[str]:
         """
@@ -187,3 +225,20 @@ class ObsidianSource(DataSource):
         pattern = r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]"
         matches = re.findall(pattern, content)
         return matches
+
+    def _build_link_map(self, md_files: List[Path]) -> Dict[str, str]:
+        link_map = {}
+        for md_file in md_files:
+            try:
+                relative_path = md_file.relative_to(self.vault_path)
+                link_map[md_file.stem] = str(relative_path)
+            except ValueError:
+                continue
+        return link_map
+
+    def _resolve_wikilinks(self, wikilinks: List[str], link_map: Dict[str, str]) -> List[str]:
+        resolved = []
+        for link in wikilinks:
+            key = Path(link).stem
+            resolved.append(link_map.get(key, link))
+        return resolved

--- a/src/storage/base.py
+++ b/src/storage/base.py
@@ -55,6 +55,11 @@ class VectorStore(ABC):
         pass
 
     @abstractmethod
+    def get_by_ids(self, ids: List[str]) -> List[Tuple[str, str, Dict[str, Any]]]:
+        """Fetch documents by IDs."""
+        pass
+
+    @abstractmethod
     def get_collection_stats(self) -> Dict[str, Any]:
         """Get statistics about the collection."""
         pass

--- a/src/storage/chroma.py
+++ b/src/storage/chroma.py
@@ -114,7 +114,7 @@ class ChromaVectorStore(VectorStore):
             sanitized_metadatas.append(sanitized)
 
         try:
-            self.collection.add(
+            self.collection.upsert(
                 ids=ids,
                 embeddings=embeddings,
                 documents=texts,
@@ -181,6 +181,27 @@ class ChromaVectorStore(VectorStore):
         except Exception as e:
             print(f"[ERROR] Error searching ChromaDB: {e}")
             return []
+
+    def get_by_ids(self, ids: List[str]) -> List[Tuple[str, str, Dict[str, Any]]]:
+        """Fetch documents by IDs."""
+        if not ids:
+            return []
+
+        try:
+            results = self.collection.get(
+                ids=ids,
+                include=["documents", "metadatas"],
+            )
+        except Exception as e:
+            print(f"[ERROR] Error fetching documents by IDs: {e}")
+            return []
+
+        records = []
+        for idx, doc_id in enumerate(results.get("ids", [])):
+            text = results.get("documents", [])[idx]
+            metadata = results.get("metadatas", [])[idx]
+            records.append((doc_id, text, metadata))
+        return records
 
     def delete_collection(self) -> None:
         """Delete the entire collection."""

--- a/tests/integration/test_chroma_get_by_ids.py
+++ b/tests/integration/test_chroma_get_by_ids.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.storage.chroma import ChromaVectorStore
+
+
+@pytest.mark.integration
+@pytest.mark.requires_chromadb
+def test_chroma_get_by_ids(integration_config):
+    config = dict(integration_config)
+    storage_config = dict(config.get("storage", {}))
+    storage_config["collection_name"] = "test_get_by_ids"
+    config["storage"] = storage_config
+
+    try:
+        store = ChromaVectorStore(config)
+    except Exception as exc:
+        pytest.skip(f"ChromaDB not available: {exc}")
+
+    store.add_documents(
+        texts=["alpha", "beta"],
+        embeddings=[[0.1, 0.2], [0.2, 0.3]],
+        metadatas=[{"label": "a"}, {"label": "b"}],
+        ids=["doc-a", "doc-b"],
+    )
+
+    results = store.get_by_ids(["doc-a", "doc-b"])
+    ids = {doc_id for doc_id, _, _ in results}
+
+    assert {"doc-a", "doc-b"} == ids
+
+    store.delete_collection()

--- a/tests/integration/test_query_rerank_ordering.py
+++ b/tests/integration/test_query_rerank_ordering.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.pipeline import ResearchRAGPipeline
+
+
+class DummyEmbedder:
+    def embed_query(self, query):
+        return [0.0]
+
+
+class DummyVectorStore:
+    def search(self, query_embedding, k=5):
+        return [
+            ("id-1", "first", 0.9, {}),
+            ("id-2", "second", 0.8, {}),
+        ]
+
+
+class ReverseReranker:
+    def rerank(self, query, results):
+        return list(reversed(results))
+
+
+@pytest.mark.integration
+def test_query_rerank_ordering():
+    pipeline = ResearchRAGPipeline.__new__(ResearchRAGPipeline)
+    pipeline.config = {
+        "retrieval": {
+            "k_recall": 5,
+            "rerank": {"enabled": True, "top_n": None},
+            "expand": {"include_parent": False},
+        }
+    }
+    pipeline.embedder = DummyEmbedder()
+    pipeline.vector_store = DummyVectorStore()
+    pipeline.reranker = ReverseReranker()
+
+    results = ResearchRAGPipeline.query(pipeline, "query", k=2)
+
+    assert results[0][0] == "id-2"
+    assert results[1][0] == "id-1"

--- a/tests/pipeline/test_minimal_pipeline_end_to_end.py
+++ b/tests/pipeline/test_minimal_pipeline_end_to_end.py
@@ -1,0 +1,62 @@
+import pytest
+
+from src.pipeline import ResearchRAGPipeline
+from src.processing.chunker import TextChunker
+from src.sources.base import Document
+
+
+class DummyEmbedder:
+    def embed_texts(self, texts):
+        return [[float(len(text))] for text in texts]
+
+    def embed_query(self, query):
+        return [float(len(query))]
+
+
+class DummyVectorStore:
+    def __init__(self):
+        self.records = []
+
+    def add_documents(self, texts, embeddings, metadatas, ids=None):
+        for doc_id, text, metadata in zip(ids, texts, metadatas):
+            self.records.append((doc_id, text, 1.0, metadata))
+
+    def search(self, query_embedding, k=5):
+        return self.records[:k]
+
+
+class ReverseReranker:
+    def rerank(self, query, results):
+        return list(reversed(results))
+
+
+@pytest.mark.pipeline
+@pytest.mark.slow
+def test_minimal_pipeline_end_to_end():
+    pipeline = ResearchRAGPipeline.__new__(ResearchRAGPipeline)
+    pipeline.config = {
+        "chunking": {"chunk_size": 50, "chunk_overlap": 0, "strategy": "recursive"},
+        "retrieval": {
+            "k_recall": 5,
+            "rerank": {"enabled": True, "top_n": None},
+            "expand": {"include_parent": False},
+        },
+    }
+    pipeline.chunker = TextChunker(pipeline.config)
+    pipeline.embedder = DummyEmbedder()
+    pipeline.vector_store = DummyVectorStore()
+    pipeline.reranker = ReverseReranker()
+
+    documents = [
+        Document("First document content.", {"source_type": "obsidian"}, doc_id="doc-1"),
+        Document("Second document content.", {"source_type": "obsidian"}, doc_id="doc-2"),
+    ]
+
+    chunks, metadatas, ids = ResearchRAGPipeline._chunk_batch(pipeline, documents)
+    embeddings = pipeline.embedder.embed_texts(chunks)
+    pipeline._store_batch(chunks, embeddings, metadatas, ids)
+
+    results = ResearchRAGPipeline.query(pipeline, "query", k=2)
+
+    assert results
+    assert results[0][0] == ids[-1]

--- a/tests/unit/test_chunk_id_stability.py
+++ b/tests/unit/test_chunk_id_stability.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.processing.id_utils import attach_parent_ids, stable_chunk_id
+
+
+@pytest.mark.unit
+def test_stable_chunk_id_is_deterministic():
+    chunk_id_1 = stable_chunk_id("doc-1", "mid", 0, "hello world")
+    chunk_id_2 = stable_chunk_id("doc-1", "mid", 0, "hello world")
+
+    assert chunk_id_1 == chunk_id_2
+
+
+@pytest.mark.unit
+def test_stable_chunk_id_changes_with_text():
+    base_id = stable_chunk_id("doc-1", "mid", 0, "hello world")
+    changed_id = stable_chunk_id("doc-1", "mid", 0, "hello world!")
+
+    assert base_id != changed_id
+
+
+@pytest.mark.unit
+def test_attach_parent_ids_sets_parent_id():
+    metadatas = [
+        {"chunk_level": "mid", "chunk_index": 0},
+        {"chunk_level": "fine", "chunk_index": 0, "parent_level": "mid", "parent_ordinal": 0},
+    ]
+    ids = [
+        stable_chunk_id("doc-1", "mid", 0, "mid text"),
+        stable_chunk_id("doc-1", "fine", 1, "fine text"),
+    ]
+
+    attach_parent_ids(metadatas, ids)
+
+    assert metadatas[1]["parent_id"] == ids[0]

--- a/tests/unit/test_hierarchical_metadata.py
+++ b/tests/unit/test_hierarchical_metadata.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.processing.chunkers.hierarchical import HierarchicalChunker
+from src.processing.id_utils import attach_parent_ids, stable_chunk_id
+
+
+@pytest.mark.unit
+def test_hierarchical_chunking_sets_parent_ids():
+    config = {
+        "chunking": {
+            "defaults": {"chunk_size": 50, "chunk_overlap": 0, "strategy": "recursive"},
+            "huge_docs": {
+                "enabled": True,
+                "levels": {
+                    "coarse": {"chunk_size": 120, "chunk_overlap": 0},
+                    "mid": {"chunk_size": 60, "chunk_overlap": 0},
+                    "fine": {"chunk_size": 30, "chunk_overlap": 0},
+                },
+            },
+        }
+    }
+    chunker = HierarchicalChunker(config)
+    text = "Sentence one. Sentence two. Sentence three. Sentence four. " * 5
+    chunks = chunker.chunk_with_metadata(text, {"source_type": "pdf"})
+
+    metadatas = [metadata for _, metadata in chunks]
+    ids = [
+        stable_chunk_id("doc-1", metadata.get("chunk_level", "mid"), idx, chunk_text)
+        for idx, (chunk_text, metadata) in enumerate(chunks)
+    ]
+
+    attach_parent_ids(metadatas, ids)
+
+    fine_chunks = [metadata for metadata in metadatas if metadata.get("chunk_level") == "fine"]
+    assert fine_chunks
+    assert all(metadata.get("parent_id") for metadata in fine_chunks)

--- a/tests/unit/test_markdown_chunking.py
+++ b/tests/unit/test_markdown_chunking.py
@@ -1,0 +1,34 @@
+import pytest
+
+from src.processing.chunkers.markdown import MarkdownChunker
+
+
+@pytest.mark.unit
+def test_markdown_chunking_respects_headings_and_code_blocks():
+    config = {
+        "chunking": {
+            "defaults": {"chunk_size": 80, "chunk_overlap": 0, "strategy": "recursive"},
+            "markdown": {"header_levels": [1, 2], "max_section_tokens": 10},
+        }
+    }
+    chunker = MarkdownChunker(config)
+    text = """
+# Heading One
+
+Intro paragraph.
+
+```python
+print("hello")
+```
+
+## Subheading
+
+More text here.
+""".strip()
+
+    chunks = chunker.chunk_with_metadata(text, {"source_type": "obsidian"})
+
+    assert chunks
+    assert any(metadata.get("heading_path") == "Heading One" for _, metadata in chunks)
+    assert any(metadata.get("contains_code") for _, metadata in chunks)
+    assert any("```python" in chunk_text and "```" in chunk_text for chunk_text, _ in chunks)

--- a/tests/unit/test_router_routing.py
+++ b/tests/unit/test_router_routing.py
@@ -1,0 +1,53 @@
+import pytest
+
+from src.processing.router import ChunkerRouter
+
+
+@pytest.mark.unit
+def test_router_routes_zotero_annotations_to_atomic():
+    config = {"chunking": {"router_enabled": True}}
+    router = ChunkerRouter(config)
+    metadata = {"source_type": "zotero_annotation"}
+    chunks = router.chunk_with_metadata("annotation text", metadata)
+
+    assert chunks
+    assert chunks[0][1]["chunk_level"] == "atomic"
+
+
+@pytest.mark.unit
+def test_router_routes_obsidian_to_markdown():
+    config = {
+        "chunking": {
+            "router_enabled": True,
+            "markdown": {"enabled": True, "header_levels": [1]},
+            "defaults": {"chunk_size": 100, "chunk_overlap": 0, "strategy": "recursive"},
+        }
+    }
+    router = ChunkerRouter(config)
+    metadata = {"source_type": "obsidian"}
+    text = "# Title\n\nParagraph text."
+    chunks = router.chunk_with_metadata(text, metadata)
+
+    assert chunks
+    assert chunks[0][1]["heading_path"] == "Title"
+
+
+@pytest.mark.unit
+def test_router_routes_huge_docs_to_hierarchical():
+    config = {
+        "chunking": {
+            "router_enabled": True,
+            "huge_docs": {
+                "enabled": True,
+                "huge_doc_tokens": 10,
+                "levels": {"coarse": {"chunk_size": 40, "chunk_overlap": 0}},
+            },
+            "defaults": {"chunk_size": 20, "chunk_overlap": 0, "strategy": "recursive"},
+        }
+    }
+    router = ChunkerRouter(config)
+    metadata = {"source_type": "pdf"}
+    text = "This is a long document that should trigger hierarchical chunking." * 5
+    chunks = router.chunk_with_metadata(text, metadata)
+
+    assert any(chunk_metadata.get("chunk_level") == "coarse" for _, chunk_metadata in chunks)


### PR DESCRIPTION
### Motivation

- Treat Obsidian as structured Markdown (frontmatter, tags, wikilinks) and preserve those semantics in chunk metadata for cross-source joins and future graph traversal.  
- Introduce a single router + specialized chunkers to respect headings/code blocks and provide hierarchical lineage for huge documents.  
- Make embedding and rerank providers pluggable so providers (LM Studio / OpenAI) can be swapped without touching pipeline logic.  
- Provide stable IDs and parent linking so resumable delta indexing/upserts avoid duplicates and parent-context expansion is possible.

### Description

- Add factories `create_chunker`, `create_embedder`, and `create_reranker` and wire them into the pipeline so provider-specific code is isolated behind factories (`src/factories/*`, `src/pipeline.py`).
- Implement a chunker router and three chunkers: `MarkdownChunker`, `HierarchicalChunker`, and `AtomicChunker`, with lineage/parent metadata and code-block-safe splitting (`src/processing/router.py`, `src/processing/chunkers/*`).
- Enhance Obsidian ingestion to parse YAML frontmatter verbatim, extract YAML + inline tags, capture wikilinks (resolved when possible), preserve `frontmatter` in metadata, and propagate `zotero_key` to note metadata (`src/sources/obsidian.py`).
- Add stable chunk ID generation and parent-id attachment utilities, parent-context expansion, an LLM-based reranker that supports LM Studio and OpenAI backends, and an OpenAI embedding provider; update Chroma storage to `upsert` and add `get_by_ids` (`src/processing/id_utils.py`, `src/retrieval/*`, `src/embedding/*`, `src/storage/chroma.py`).

### Testing

- Ran unit tests: `tests/unit/test_chunk_id_stability.py`, `tests/unit/test_router_routing.py`, `tests/unit/test_markdown_chunking.py`, and `tests/unit/test_hierarchical_metadata.py`. All tests passed (`8 passed`).
- Added integration tests for `Chroma.get_by_ids` and query/rerank ordering under `tests/integration/`, and a minimal pipeline smoke under `tests/pipeline/` for later CI execution. 
- The changes include documentation and an updated `config.example.yaml` showing `chunking`, `retrieval`, and provider configuration for LM Studio / OpenAI. 
- No manual validation is reported here; automated unit suite above was executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5407d6108332985e6cf69fce73d4)